### PR TITLE
Update Front Row to Freckle

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Some of these companies support remote hires. Where that information is availabl
 [Facebook](https://www.facebook.com) | London, UK | Advertising | [Blog](https://code.facebook.com/posts/745068642270222/fighting-spam-with-haskell/)
 [Factis Research](http://www.factisresearch.com) | Freiburg, Germany | Medicare | [Github](https://github.com/factisresearch?language=haskell)
 [FretLink](https://www.fretlink.com) | Paris, France | Logistics/Transportation | [Reddit](https://www.reddit.com/r/haskell/comments/6p2x0p/list_of_companies_that_use_haskell/dkpp1gg/)
-[Front Row Education](http://frontrowed.com) | San Francisco, CA, USA/Remote | Education | [Github](https://github.com/frontrowed?language=haskell)|Yes
+[Freckle Education (formerly Front Row)](https://www.freckle.com) | San Francisco, CA, USA | Education | [Github](https://github.com/frontrowed?language=haskell)|Yes
 [FP Complete](https://www.fpcomplete.com) | Remote | Consulting/Training | [Github](https://github.com/fpco?language=haskell)|Yes
 [Fugue](https://fugue.co) | Washington, DC, USA | Automation | ?
 [Futurice](https://futurice.com) | Helsinki, Finland | Software | [Github](https://github.com/futurice?language=haskell) | No


### PR DESCRIPTION
We changed our name a couple of weeks ago. Happy to drop the `(formerly Front Row)` if it's too busy, but thought it might make us easier to find.