### PR TITLE
Company Change

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Some of these companies support remote hires. Where that information is availabl
 [Arbor Networks](https://www.arbornetworks.com) | Australia, Sydney | Anti-DDOS | [Twitter](https://twitter.com/newhoggy/status/850125796244987904) | Yes (for similar timezones)
 [Asahi Net](https://asahi-net.jp/en/) | JP | ISP | [Hacker News](https://news.ycombinator.com/item?id=13306004)
 [Assertible](https://assertible.com) | USA | SaaS/Monitoring | [Reddit](https://www.reddit.com/r/haskell/comments/6p2x0p/list_of_companies_that_use_haskell/dkrw4b3/)
-[Atos IT Solutions and Services](https://atos.net/en) | Austria | Aerospace | [Youtube](https://youtu.be/Wu8eJh6OqhI?list=PLp2qifo30hMunt6PW7yXIOTZkixJsZXgA) | Negotiable
+[Atos IT Solutions and Services](https://atos.net/en) | Austria | Aerospace | [Youtube](https://youtu.be/Wu8eJh6OqhI?list=PLp2qifo30hMunt6PW7yXIOTZkixJsZXgA) | 
 [Awake Security](http://awakesecurity.com) | USA, CA, Sunnyvale | Network Security | [Reddit](https://www.reddit.com/r/haskell/comments/4p66um/what_languages_do_you_use_for_work_to_make_money/d4issty/) | Yes
 [Azara](https://www.azara.io/) | USA, CO, Boulder | Compliance | [Reddit](https://web.archive.org/web/20180306071153/https://www.reddit.com/r/haskell/comments/827na2/azara_is_hiring/) | Yes
 [Barclays](http://www.barclays.co.uk) | UK, London | Finance | [Blog](http://neilmitchell.blogspot.se/2016/09/full-time-haskell-jobs-in-london-at.html)

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Some of these companies support remote hires. Where that information is availabl
 [Arbor Networks](https://www.arbornetworks.com) | Australia, Sydney | Anti-DDOS | [Twitter](https://twitter.com/newhoggy/status/850125796244987904) | Yes (for similar timezones)
 [Asahi Net](https://asahi-net.jp/en/) | JP | ISP | [Hacker News](https://news.ycombinator.com/item?id=13306004)
 [Assertible](https://assertible.com) | USA | SaaS/Monitoring | [Reddit](https://www.reddit.com/r/haskell/comments/6p2x0p/list_of_companies_that_use_haskell/dkrw4b3/)
+[Atos IT Solutions and Services](https://atos.net/en) | Austria | Aerospace | [Youtube](https://youtu.be/Wu8eJh6OqhI?list=PLp2qifo30hMunt6PW7yXIOTZkixJsZXgA) | Negotiable
 [Awake Security](http://awakesecurity.com) | USA, CA, Sunnyvale | Network Security | [Reddit](https://www.reddit.com/r/haskell/comments/4p66um/what_languages_do_you_use_for_work_to_make_money/d4issty/) | Yes
 [Azara](https://www.azara.io/) | USA, CO, Boulder | Compliance | [Reddit](https://web.archive.org/web/20180306071153/https://www.reddit.com/r/haskell/comments/827na2/azara_is_hiring/) | Yes
 [Barclays](http://www.barclays.co.uk) | UK, London | Finance | [Blog](http://neilmitchell.blogspot.se/2016/09/full-time-haskell-jobs-in-london-at.html)
@@ -123,7 +124,6 @@ Karamaan Group | USA, NY, New York | Finance | ?
 [Seller Labs](https://www.sellerlabs.com) | USA, GA, Athens | E-Commerce | [Github](https://github.com/sellerlabs?language=haskell)
 [Sentenai](http://sentenai.com) | USA, MA, Boston | IoT / Databases | [Github](https://github.com/Sentenai) [Angellist](https://angel.co/sentenai) | Negotiable | 
 [Serokell](https://serokell.io) | Russia, Sankt-Petersburg | Consulting, research | [Github](https://github.com/serokell?language=github) | Yes
-[Siemens Convergence Creators](http://www.convergence-creators.siemens.com) | Austria, Vienna | ? | ? | ?
 [Simply RETS](https://simplyrets.com) | USA, TX, Houston | SaaS (Real Estate) | ?
 [SimSpace](https://simspace.com) | USA, MA, Boston | Computer Security | [Github](https://github.com/Simspace?language=haskell) [AngelList](https://angel.co/simspace/jobs/64261-software-engineer-backend) | Yes (US/CA/Mexico)
 [Skedge](http://skedge.me) | USA, NY, New York | ? | ?


### PR DESCRIPTION
Hello,

The company Siemens Convergence Creators has been bought by the Atos group, hence I updated the information a bit. I deleted the Siemens CC because it no longer exists as a company, and added Atos IT Solutions & Services, which is now the official company name.

Haskell is used in the Space department in the mission control sector for various test systems and is currently under evaluation for direct use in mission control and satellite test systems. Its just our department (Aerospace) using Haskell (at least that I know of), but our tools are also in use by DLR (Deutsches Zentrum für Luft- und Raumfahrt) to test the actual mission control system GECCOS before new versions get deployed. 
I am also pushing Haskell a bit within Atos (gave a talk to the internal Atos Software Experts Community which was also forwared to ESA) an hope to get it adopted a bit more inside the company.

lg,
Michael