### PR TITLE
Add Tontine Trust Digital Pan-European Pensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Karamaan Group | United States, NY, New York | Finance | ?
 [ThoughtLeadr](http://www.thoughtleadr.com) | United States; Worldwide, TX, Austin | Advertisement/Analytics | [Github](https://github.com/ThoughtLeadr?q=&type=source&language=haskell) | Yes
 [Tiko](https://tiko.energy/) | Zurich, Switzerland/Milan, Italy | Energy management | [Job Ad](https://www.reddit.com/r/haskell/comments/at19i2/haskell_job_opportunity_at_tikoch_in_zurich_area/) [Job Ad](https://www.linkedin.com/jobs/view/1563333504) | ? |
 [Tocoman](https://tocoman.fi/en) | Finland, Helsinki | Planning software | [Reddit](https://web.archive.org/web/20180128122009/https://www.reddit.com/r/haskell/comments/7rhfot/haskell_job_opportunity_at_tocoman_in_helsinki/)
+[TontineTrust](https://tontine.com/) | Dublin, Ireland | Fintech | [Reddit](https://www.reddit.com/r/haskell/comments/gib8yk/look_forward_to_a_parttime_haskell_job/fqguilf?utm_source=share&utm_medium=web2x) | Yes
 [Tracsis](https://www.tracsis.com) | United Kingdom, Leeds | Railway Timetabling | [Job Ad](https://tracsis.com/careers/20180905-senior-software-developer-) | No
 [Trigram](http://trigram.no) | Norway, Stavanger | Language Processing | [Reddit](https://www.reddit.com/r/haskell/comments/5pan74/looking_for_haskell_companies_outside_United_States/dcrbn1q)
 [Tripshot](https://www.tripshot.com) | United States, OR/Remote, Portland | Logistics planning | [Github](https://github.com/Tripshot?language=haskell) | with US work permit


### PR DESCRIPTION
TontineTrust is using applied mathematics, behavioural science & a ruthless obsession with digitisation to disrupt the comatose jurassic era beast that calls itself the pensions industry.