### PR TITLE
Remove stale Jobs Link from CollegeVine

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Some of these companies support remote hires. Where that information is availabl
 [CJ Affiliate](https://www.cj.com/) | United States, CA, Los Angeles/Santa Barbara/Westlake Village | Marketing | [GitHub](https://github.com/cjdev?language=haskell) [Job Posting](https://engineering.cj.com/join) | No
 [Clearmatics](http://www.clearmatics.com) | United Kingdom, London | Finance | [Blog](http://www.stephendiehl.com/posts/haskell_2017.html) | Yes
 [Co-Star](https://www.costarastrology.com/) | United States, NY, New York | Astrology | [Reddit](https://www.reddit.com/r/haskell/comments/8953h8/costar_astrology_is_hiring_a_haskell_developer_in) | No
-[CollegeVine](https://www.collegevine.com/) | United States, MA, Cambridge | Education | [Jobs](https://jobs.lever.co/collegevine?team=Software%20Engineering), [GitHub](https://github.com/collegevine?language=haskell), [Blog](https://medium.com/collegevine-engineering) | Yes (US only)
+[CollegeVine](https://www.collegevine.com/) | United States, MA, Cambridge | Education | [GitHub](https://github.com/collegevine?language=haskell), [Blog](https://medium.com/collegevine-engineering) | Yes (US only)
 [Cross Compass](https://www.cross-compass.com/en/front-page/) | Tokyo, Japan | Data Science / AI | [Github](https://github.com/xc-jp) | Yes
 [Cryptium Labs](https://cryptium.ch/) | Switzerland | Blockchain research | [Job Ad](https://functional.works-hub.com/jobs/remote-blockchain-protocol-developer-7d929) | Yes
 [Data61](https://data61.csiro.au) | Australia, Multiple locations | Research | [Github](https://github.com/data61?language=haskell)


### PR DESCRIPTION
Our “Jobs” link was stale, so I’d like to just remove it, thanks!