### PR TITLE
Remove Cryptium Labs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ Some of these companies support remote hires. Where that information is availabl
 [CollegeVine](https://www.collegevine.com/) | United States, MA, Cambridge | Education | [GitHub](https://github.com/collegevine?language=haskell), [Blog](https://medium.com/collegevine-engineering) | Yes (US only)
 [Constacts](https://constacts.com) | Republic of Korea | Web applications | |
 [Cross Compass](https://www.cross-compass.com/en/front-page/) | Tokyo, Japan | Data Science / AI | [Github](https://github.com/xc-jp) | Yes
-[Cryptium Labs](https://cryptium.ch/) | Switzerland | Blockchain research | [Job Ad](https://functional.works-hub.com/jobs/remote-blockchain-protocol-developer-7d929) | Yes
 [Data61](https://data61.csiro.au) | Australia, Multiple locations | Research | [Github](https://github.com/data61?language=haskell)
 [Decathlon](https://www.decathlon.fr) | France, Lille | Retail | ? | No
 [Dfinity](https://dfinity.org) | Switzerland, Zug; United States, CA, Palo Alto | Blockchain Research | [Reddit](https://web.archive.org/web/20171010001655/https://www.reddit.com/r/haskell/comments/754346/general_questions_about_the_haskell_landscape_in/do58zog)


### PR DESCRIPTION
The website does not exist anymore (the github is still online) On Twitter they announced in 2021 that they seized operations and that the team joined a new company (https://x.com/CryptiumLabs/status/1385559726482669568)
> A reminder that @CryptiumLabs has ceased its activities as a validator on all networks on the 15th of March 2021 & has been acquired by @ChorusOne. This profile is kept for archival purposes.
> 
> The team has joined a new company and is working on a new project, the @anomanetwork

It seems that their new project has at least one repository on github that uses haskell (https://github.com/anoma/juvix).