### PR TITLE
Remove e-bot7

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ Some of these companies support remote hires. Where that information is availabl
 [Digital Asset](https://digitalasset.com) | United States, Hungary, Australia, Switzerland | Finance | [Reddit](https://www.reddit.com/r/haskell/comments/6p2x0p/list_of_companies_that_use_haskell/dknymrm/)
 [Dolla](https://dolla.org) | Remote | Consortium Blockchain | [Github](https://github.com/dolla-consortium) | Yes
 [DrieBit](https://www.driebit.nl) | Netherlands, Amsterdam | Web applications | [Job Ad](https://web.archive.org/web/20191101214309/https://haskellweekly.news/issue/181.html) | No
-[e-bot7](https://e-bot7.com) | Munich, Germany | Conversational AI | [Job Ad](https://e-bot7.join.com/jobs/1793458-senior-haskell-and-purescript-developer-m-f-d) | No
 [Facebook](https://www.facebook.com) | United Kingdom, London | Advertising | [Blog](https://code.facebook.com/posts/745068642270222/fighting-spam-with-haskell/)
 [Feram](https://www.feram.io) | Germany, Frankfurt | Consulting, Custom Software | [GitHub](https://github.com/feramhq?language=haskell) | Yes
 [FINN.no](https://www.finn.no) | Norway, Oslo | Online Classified Ads | [Blog](https://web.archive.org/save/https://tech.finn.no/2018/10/18/haskell-at-finn-no/) | No


### PR DESCRIPTION
The website does not exist anymore. Their linkedin account was renamed to [e-bot7 - AI for Customer Service (acquired by Liveperson Inc)](https://www.linkedin.com/company/e-bot7/?originalSubdomain=uk), clearly saying that they are now part of [Liveperson Inc](https://www.liveperson.com/). It is possible that this company uses Haskell as well, but I couldn't confirm that